### PR TITLE
Gate run promotion until XPB resume handshake

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -35,7 +35,11 @@ The operator-driven reset capture shows the controllers exchanging the full `RES
 ## 7. Path to resolution
 To iron out the boot-and-reset issues captured so far:
 
-* Gate the ClearCore's auto-run promotion behind an explicit XPB resume allowance (or have the XPB suppress its resume when RUN is already high) so we never enter the `ERR_WRONG_STAT` retry loop.【F:src/clearcore/ClearCoreRTM.cpp†L132-L170】【F:logs/cold_boot_no_resume.txt†L1-L17】
+* Gate the ClearCore's auto-run promotion behind an explicit XPB resume allowance (or have the XPB
+  suppress its resume when RUN is already high) so we never enter the `ERR_WRONG_STAT` retry loop.
+  **Update:** the ClearCore now ignores the latched RUN level until the switch has been observed low
+  or the XPB issues a resume/autostart, so the boot-time promotion no longer fires while the XPB is
+  still uploading the protocol.【F:src/clearcore/ClearCoreRTM.cpp†L108-L176】【F:include/ClearCoreRTM.h†L130-L410】【F:logs/cold_boot_no_resume.txt†L1-L17】
 * Surface RUN/RESET latch state on the LCD whenever the controller is not idle, and make the switch-age timer freeze explicitly signal "RUN held" so operators know why the system started without interaction.【F:src/exp-board/ExpansionBoard.cpp†L783-L829】【F:logs/user_requested_reset.txt†L69-L127】
 * Instrument the TTL transport for checksum failures and ensure duplicate `PR_END` / `QUIESCE` frames are genuine retries; add back-off so we do not spam commands when the peer already acknowledged them.【F:src/shared/TTLComms.cpp†L258-L353】【F:logs/user_requested_reset.txt†L85-L127】
 * Harden resume persistence: wrap the snapshot writer with retries and surface failures prominently, then verify the reset flow waits for a confirmed snapshot before forcing the XPB reset.【F:logs/user_requested_reset.txt†L96-L119】

--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,7 +1,7 @@
 # Boot-Up Serial Review Findings
 
 ## 1. Auto-resume races with run switch
-The ClearCore immediately transitions from `IDLE` to `RUNNING` on the first rising edge it sees from the RUN switch, even during cold boot, because it treats the latched remote RUN input as a start trigger (`runActive && !prevRunActive_`).【F:src/clearcore/ClearCoreRTM.cpp†L132-L170】 When the expansion board later issues `CMD;RESUME=AUTO;...` after completing the protocol upload, the ClearCore rejects it with `ERR_WRONG_STAT` because it is already in the `RUNNING` state and only accepts resume commands while `IDLE`.【F:include/ClearCoreRTM.h†L355-L425】 This matches the captured log where the CC reports repeated `ERR_WRONG_STAT` ACKs immediately after entering `RUNNING` when the RUN pin is latched active during boot.
+The ClearCore immediately transitions from `IDLE` to `RUNNING` on the first rising edge it sees from the RUN switch, even during cold boot, because it treats the latched remote RUN input as a start trigger (`runActive && !prevRunActive_`).【F:src/clearcore/ClearCoreRTM.cpp†L131-L182】 When the expansion board later issues `CMD;RESUME=AUTO;...` after completing the protocol upload, the ClearCore rejects it with `ERR_WRONG_STAT` because it is already in the `RUNNING` state and only accepts resume commands while `IDLE`.【F:include/ClearCoreRTM.h†L355-L425】 This matches the captured log where the CC reports repeated `ERR_WRONG_STAT` ACKs immediately after entering `RUNNING` when the XPB's active-low RUN line is held asserted during boot.
 
 The new cold boots performed with `RA.BIN`/`RB.BIN` deleted show the CC and XPB remaining in `IDLE` with steadily increasing `SW_AGE` so long as RUN stays low, proving the resume collision is limited to the “RUN held on boot” condition rather than a general resume failure.【F:logs/cold_boot_no_resume.txt†L1-L17】 Decide whether the CC should defer auto-starting until it has a chance to honor an incoming resume request, or whether the XPB should suppress the auto-resume command when it sees the CC already running.  Without that handshake, the two ends will fight and the stored resume step will never be applied.
 
@@ -11,7 +11,7 @@ With the RUN pin hard-low during boot, the XPB immediately advertises `RUN=1` th
 transitions into `RUNNING` as soon as it leaves the protocol loader.
 `ClearCoreRTM::tick()` only requires a rising edge while already in `Idle` to promote the
 state, so a latched RUN input at boot causes the CC to advance before the XPB can finish
-its auto-resume negotiation.【F:src/clearcore/ClearCoreRTM.cpp†L131-L170】【F:include/ClearCoreRTM.h†L300-L312】
+its auto-resume negotiation.【F:src/clearcore/ClearCoreRTM.cpp†L131-L177】【F:include/ClearCoreRTM.h†L300-L312】
 
 When RUN stays low—as in the new captures—the LCD’s `SW age` counter increments normally and both controllers sit in `IDLE`, so the steady-state display path checks out.【F:logs/cold_boot_no_resume.txt†L1-L17】 The problem shows up only in the latched-run boot: the LCD keeps receiving `SW;RUN=1` updates every few hundred milliseconds, so `SW age` sticks at zero even though the CC has already entered `RUNNING`. Consider exposing the latched RUN state and/or CC state string on the LCD whenever the CC is actively running so technicians can see that the system is live.【F:src/exp-board/ExpansionBoard.cpp†L783-L829】
 
@@ -23,7 +23,7 @@ The ClearCore prints a duplicate `PR_END` notice as well as `WARN: TTL bad check
 
 ## 5. Miscellaneous follow-ups
 * Confirm that the XPB backs off after the CC reports `ERR_WRONG_STAT`; the log shows multiple retries with the same REF, so ensure the retry policy stops once an explicit error ACK is received.【F:src/shared/TTLComms.cpp†L258-L353】
-* Verify whether the heater setpoint / preheat command path is exercised during an auto-resume.  If the CC suppresses auto-start to wait for XPB resume, make sure the stored step's temperature target still flows through the preheat handler before resuming motion.【F:include/ClearCoreRTM.h†L402-L423】【F:src/clearcore/ClearCoreRTM.cpp†L132-L166】
+* Verify whether the heater setpoint / preheat command path is exercised during an auto-resume.  If the CC suppresses auto-start to wait for XPB resume, make sure the stored step's temperature target still flows through the preheat handler before resuming motion.【F:include/ClearCoreRTM.h†L402-L423】【F:src/clearcore/ClearCoreRTM.cpp†L143-L177】
 
 ## 6. User-requested reset flow
 The operator-driven reset capture shows the controllers exchanging the full `RESET=ARM`/`RESET=EXEC` handshake while both ends sit in `WAITING_XPB`, so the high-level flow is wired correctly.【F:logs/user_requested_reset.txt†L1-L127】【F:logs/user_requested_reset.txt†L129-L268】 Still, three issues surface:
@@ -37,20 +37,20 @@ To iron out the boot-and-reset issues captured so far:
 
 * Gate the ClearCore's auto-run promotion behind an explicit XPB resume allowance (or have the XPB
   suppress its resume when RUN is already high) so we never enter the `ERR_WRONG_STAT` retry loop.
-  **Update:** the ClearCore now ignores the latched RUN level until the switch has been observed low
-  or the XPB issues a resume/autostart, so the boot-time promotion no longer fires while the XPB is
-  still uploading the protocol.【F:src/clearcore/ClearCoreRTM.cpp†L108-L180】【F:include/ClearCoreRTM.h†L131-L220】【F:logs/cold_boot_no_resume.txt†L1-L17】
+  **Update:** the ClearCore now treats the XPB's active-low RUN input as gated until it either sees
+  the line released high or the XPB issues a resume/autostart, so a latched low no longer promotes
+  the state machine while the XPB is still uploading the protocol.【F:src/clearcore/ClearCoreRTM.cpp†L102-L203】【F:include/ClearCoreRTM.h†L131-L220】【F:logs/cold_boot_no_resume.txt†L1-L17】
   * **Validation plan:**
-    1. Cold-boot the ClearCore with the RUN rocker latched high and confirm the state machine logs
-       `[RUN] Ignoring latched RUN...` while remaining in `BOOT/PROTO_LOADING` until either the
-       switch is toggled low or the XPB issues `RESUME AUTOSTART=1`; this exercises the
-       `runEdgeArmed_` guard added in `tick()` and reset in `handleBoot()`.【F:src/clearcore/ClearCoreRTM.cpp†L131-L181】【F:src/clearcore/ClearCoreRTM.cpp†L255-L281】
-    2. After the XPB handshake completes, toggle RUN low then high and verify the controller
-       transitions from `IDLE` to `PREHEAT/RUN` as before, demonstrating that the guard re-arms once
-       a low level is observed and allows intentional rises.【F:src/clearcore/ClearCoreRTM.cpp†L132-L177】
-    3. From `IDLE`, command an XPB `RESUME AUTOSTART=1` with RUN already high and confirm the
-       ClearCore accepts the resume, sets up preheat if required, and only then promotes into motion;
-       this covers the resume handler releasing the guard for coordinated auto-starts.【F:include/ClearCoreRTM.h†L360-L413】
+    1. Cold-boot both controllers with the XPB RUN pin held low (call-for-run) and confirm the CC
+       stays in `BOOT/PROTO_LOADING` while logging `[RUN] Ignoring RUN line held low before XPB
+       resume` until the line is released high or a `RESUME AUTOSTART=1` arrives; this exercises the
+       `runGateReleased_` guard reset in `handleBoot()`.【F:src/clearcore/ClearCoreRTM.cpp†L108-L200】
+    2. After the XPB handshake completes, momentarily release RUN high and drive it low again to
+       verify the controller transitions from `IDLE` into `PREHEAT/RUN`, proving the gate opens once
+       the active-low line has been seen high.【F:src/clearcore/ClearCoreRTM.cpp†L120-L177】
+    3. From `IDLE`, send `RESUME AUTOSTART=1` while keeping RUN asserted low and confirm the
+       ClearCore accepts the resume and advances only after the XPB command; this covers the resume
+       handler overriding the gate for coordinated auto-starts.【F:include/ClearCoreRTM.h†L360-L413】
 * Surface RUN/RESET latch state on the LCD whenever the controller is not idle, and make the switch-age timer freeze explicitly signal "RUN held" so operators know why the system started without interaction.【F:src/exp-board/ExpansionBoard.cpp†L783-L829】【F:logs/user_requested_reset.txt†L69-L127】
 * Instrument the TTL transport for checksum failures and ensure duplicate `PR_END` / `QUIESCE` frames are genuine retries; add back-off so we do not spam commands when the peer already acknowledged them.【F:src/shared/TTLComms.cpp†L258-L353】【F:logs/user_requested_reset.txt†L85-L127】
 * Harden resume persistence: wrap the snapshot writer with retries and surface failures prominently, then verify the reset flow waits for a confirmed snapshot before forcing the XPB reset.【F:logs/user_requested_reset.txt†L96-L119】

--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -39,7 +39,18 @@ To iron out the boot-and-reset issues captured so far:
   suppress its resume when RUN is already high) so we never enter the `ERR_WRONG_STAT` retry loop.
   **Update:** the ClearCore now ignores the latched RUN level until the switch has been observed low
   or the XPB issues a resume/autostart, so the boot-time promotion no longer fires while the XPB is
-  still uploading the protocol.【F:src/clearcore/ClearCoreRTM.cpp†L108-L176】【F:include/ClearCoreRTM.h†L130-L410】【F:logs/cold_boot_no_resume.txt†L1-L17】
+  still uploading the protocol.【F:src/clearcore/ClearCoreRTM.cpp†L108-L180】【F:include/ClearCoreRTM.h†L131-L220】【F:logs/cold_boot_no_resume.txt†L1-L17】
+  * **Validation plan:**
+    1. Cold-boot the ClearCore with the RUN rocker latched high and confirm the state machine logs
+       `[RUN] Ignoring latched RUN...` while remaining in `BOOT/PROTO_LOADING` until either the
+       switch is toggled low or the XPB issues `RESUME AUTOSTART=1`; this exercises the
+       `runEdgeArmed_` guard added in `tick()` and reset in `handleBoot()`.【F:src/clearcore/ClearCoreRTM.cpp†L131-L181】【F:src/clearcore/ClearCoreRTM.cpp†L255-L281】
+    2. After the XPB handshake completes, toggle RUN low then high and verify the controller
+       transitions from `IDLE` to `PREHEAT/RUN` as before, demonstrating that the guard re-arms once
+       a low level is observed and allows intentional rises.【F:src/clearcore/ClearCoreRTM.cpp†L132-L177】
+    3. From `IDLE`, command an XPB `RESUME AUTOSTART=1` with RUN already high and confirm the
+       ClearCore accepts the resume, sets up preheat if required, and only then promotes into motion;
+       this covers the resume handler releasing the guard for coordinated auto-starts.【F:include/ClearCoreRTM.h†L360-L413】
 * Surface RUN/RESET latch state on the LCD whenever the controller is not idle, and make the switch-age timer freeze explicitly signal "RUN held" so operators know why the system started without interaction.【F:src/exp-board/ExpansionBoard.cpp†L783-L829】【F:logs/user_requested_reset.txt†L69-L127】
 * Instrument the TTL transport for checksum failures and ensure duplicate `PR_END` / `QUIESCE` frames are genuine retries; add back-off so we do not spam commands when the peer already acknowledged them.【F:src/shared/TTLComms.cpp†L258-L353】【F:logs/user_requested_reset.txt†L85-L127】
 * Harden resume persistence: wrap the snapshot writer with retries and surface failures prominently, then verify the reset flow waits for a confirmed snapshot before forcing the XPB reset.【F:logs/user_requested_reset.txt†L96-L119】

--- a/include/ClearCoreRTM.h
+++ b/include/ClearCoreRTM.h
@@ -131,7 +131,7 @@ private:
     /* ——— user input ——— */
     bool        runActiveRemote_   = false;
     bool        resetActiveRemote_ = false;
-    bool        runEdgeArmed_      = false; //!< Defers RUN rising edges until XPB handshake/low seen
+    bool        runGateReleased_   = false; //!< RUN line (active-low) ignored until XPB grants start or a high level is observed
     uint32_t    swLastUpdateMs_    = 0;
 
     // string mapping for displaying active state on LCD
@@ -390,7 +390,7 @@ private:
                         owner_->loopCount_ = owner_->totalLoops_ - (uint32_t)resumeLoop + 1;
 
                         // Allow future RUN edges now that XPB has explicitly coordinated resume
-                        owner_->runEdgeArmed_ = true;
+                        owner_->runGateReleased_ = true;   // XPB explicitly allowed coordinated start
 
                         // --- Gating Rules ---
                         // if AUTOSTART==0 or RUN is not LOW, don't preheat nor start.

--- a/include/ClearCoreRTM.h
+++ b/include/ClearCoreRTM.h
@@ -131,6 +131,7 @@ private:
     /* ——— user input ——— */
     bool        runActiveRemote_   = false;
     bool        resetActiveRemote_ = false;
+    bool        runEdgeArmed_      = false; //!< Defers RUN rising edges until XPB handshake/low seen
     uint32_t    swLastUpdateMs_    = 0;
 
     // string mapping for displaying active state on LCD
@@ -387,7 +388,10 @@ private:
                         // Apply the resume position
                         owner_->currentStep_ = (uint16_t)(resumeStep - 1);  // Convert to 0-based index
                         owner_->loopCount_ = owner_->totalLoops_ - (uint32_t)resumeLoop + 1;
-                        
+
+                        // Allow future RUN edges now that XPB has explicitly coordinated resume
+                        owner_->runEdgeArmed_ = true;
+
                         // --- Gating Rules ---
                         // if AUTOSTART==0 or RUN is not LOW, don't preheat nor start.
                         if (autoStart != 1 || !runIsEngaged) {

--- a/src/clearcore/ClearCoreRTM.cpp
+++ b/src/clearcore/ClearCoreRTM.cpp
@@ -105,7 +105,7 @@ void ClearCoreRTM::tick() {
     }
 
     bool eStopActive  = !SAFETY_PIN.State();
-    bool runActive    = runActiveRemote_;
+    const bool runLineLow = runActiveRemote_;   // XPB publishes RUN=1 when the active-low line is asserted
     bool resetActive  = resetActiveRemote_;
 
     // first check for E-Stop
@@ -128,18 +128,20 @@ void ClearCoreRTM::tick() {
         }
         prevResetActive_ = resetActive;
 
-        const bool runRise = runActive && !prevRunActive_;
-        if (!runEdgeArmed_ && !runActive) {
-            runEdgeArmed_ = true;   // saw a low level -> future rises are intentional
+        const bool runRoseLow = runLineLow && !prevRunActive_;
+        const bool runWentHigh = !runLineLow && prevRunActive_;
+        if (!runGateReleased_ && runWentHigh) {
+            runGateReleased_ = true;   // XPB line returned high, treat future low transitions as intentional
+            dbgln("[RUN] Gate released: XPB RUN returned high");
         }
 
-        const bool runRiseAllowed = runRise && runEdgeArmed_;
-        if (runRise && !runEdgeArmed_) {
-            dbgln("[RUN] Ignoring latched RUN (awaiting XPB resume)");
+        const bool runRiseAllowed = runRoseLow && runGateReleased_;
+        if (runRoseLow && !runGateReleased_) {
+            dbgln("[RUN] Ignoring RUN line held low before XPB resume");
         }
 
         // --- RUN logic: pause on level, start/resume on RISING EDGE only ---
-        if (!runActive && !resetActive && state_ == State::Running) {
+        if (!runLineLow && !resetActive && state_ == State::Running) {
             // switch moved out of RUN while running -> pause
             state_ = State::Paused;
         }
@@ -177,7 +179,7 @@ void ClearCoreRTM::tick() {
         }
 
         // latch for next tick
-        prevRunActive_ = runActive;
+        prevRunActive_ = runLineLow;
     }
 
     // justEntered_ allows us to do things once upon first entering a state handler
@@ -191,22 +193,22 @@ void ClearCoreRTM::tick() {
     // dispatch to state handlers
     switch (state_) {
         case State::BOOT:
-            handleBoot(runActive, justEntered_);
+            handleBoot(resetActive, justEntered_);
             break;
         case State::PROTO_LOADING:
             handleProtoLoad(justEntered_);
             break;
         case State::Idle:
-            handleIdle(runActive, justEntered_);
+            handleIdle(runLineLow, justEntered_);
             break;
         case State::Preheat:
-            handlePreheat(runActive, justEntered_);
+            handlePreheat(runLineLow, justEntered_);
             break;
         case State::Running:
-            handleRunning(runActive, justEntered_);
+            handleRunning(runLineLow, justEntered_);
             break;
         case State::Paused:
-            handlePaused(runActive, justEntered_);
+            handlePaused(runLineLow, justEntered_);
             break;
         case State::ResetRequested:
             handleReset(resetActive, justEntered_);
@@ -215,7 +217,7 @@ void ClearCoreRTM::tick() {
             handleEStop(resetActive, justEntered_);
             break;
         case State::Resume:
-            handleResume(runActive, justEntered_);
+            handleResume(runLineLow, justEntered_);
             break;
         case State::Completed:
             handleCompleted(resetActive, justEntered_);
@@ -254,7 +256,7 @@ void ClearCoreRTM::tick() {
 /* ——— State Handlers ——— */
 void ClearCoreRTM::handleBoot(bool resetActive, bool justEntered_) {
     if (justEntered_) {
-        runEdgeArmed_ = false;   // always re-arm the RUN gate on cold boot/protocol reload
+        runGateReleased_ = false;   // active-low RUN stays masked until XPB grants it again
         heartbeatSystemEnabled_ = false;
         protoRequestTmr_ = 0;
 

--- a/src/clearcore/ClearCoreRTM.cpp
+++ b/src/clearcore/ClearCoreRTM.cpp
@@ -128,12 +128,22 @@ void ClearCoreRTM::tick() {
         }
         prevResetActive_ = resetActive;
 
+        const bool runRise = runActive && !prevRunActive_;
+        if (!runEdgeArmed_ && !runActive) {
+            runEdgeArmed_ = true;   // saw a low level -> future rises are intentional
+        }
+
+        const bool runRiseAllowed = runRise && runEdgeArmed_;
+        if (runRise && !runEdgeArmed_) {
+            dbgln("[RUN] Ignoring latched RUN (awaiting XPB resume)");
+        }
+
         // --- RUN logic: pause on level, start/resume on RISING EDGE only ---
         if (!runActive && !resetActive && state_ == State::Running) {
             // switch moved out of RUN while running -> pause
             state_ = State::Paused;
         }
-        else if ((runActive && !prevRunActive_) && state_ == State::Paused) {
+        else if (runRiseAllowed && state_ == State::Paused) {
             // If cold start and targetC > 0 we should preheat before resuming motion
             const uint16_t targetC = steps_[currentStep_].tempC;
             if (coldStart_ && targetC > 0) {
@@ -150,7 +160,7 @@ void ClearCoreRTM::tick() {
                 state_ = State::Resume;          // fast path, no preheat needed
             }
         }
-        else if ((runActive && !prevRunActive_) && state_ == State::Idle) {
+        else if (runRiseAllowed && state_ == State::Idle) {
             const uint16_t targetC = steps_[currentStep_].tempC;
             if (coldStart_ && targetC > 0) {
                 state_                 = State::Preheat;
@@ -243,7 +253,8 @@ void ClearCoreRTM::tick() {
 
 /* ——— State Handlers ——— */
 void ClearCoreRTM::handleBoot(bool resetActive, bool justEntered_) {
-    if (justEntered_) { 
+    if (justEntered_) {
+        runEdgeArmed_ = false;   // always re-arm the RUN gate on cold boot/protocol reload
         heartbeatSystemEnabled_ = false;
         protoRequestTmr_ = 0;
 


### PR DESCRIPTION
## Summary
- add a RUN-edge gate so the ClearCore ignores the latched switch level until XPB coordination
- reset and release the gate during XPB resume handling to prevent boot-time auto-starts
- document the new behavior in the review log for the path-to-resolution item

## Testing
- not run (firmware-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e919e2fe248321a81267a37da68d4c