### PR TITLE
Allow latched RUN to auto-resume after protocol upload

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,7 +1,7 @@
 # Boot-Up Serial Review Findings
 
 ## 1. Auto-resume races with run switch
-The ClearCore immediately transitions from `IDLE` to `RUNNING` on the first rising edge it sees from the RUN switch, even during cold boot, because it treats the latched remote RUN input as a start trigger (`runActive && !prevRunActive_`).【F:src/clearcore/ClearCoreRTM.cpp†L132-L170】 When the expansion board later issues `CMD;RESUME=AUTO;...` after completing the protocol upload, the ClearCore rejects it with `ERR_WRONG_STAT` because it is already in the `RUNNING` state and only accepts resume commands while `IDLE`.【F:include/ClearCoreRTM.h†L355-L425】 This matches the captured log where the CC reports repeated `ERR_WRONG_STAT` ACKs immediately after entering `RUNNING` when the RUN pin is latched active during boot.
+The ClearCore immediately transitions from `IDLE` to `RUNNING` on the first rising edge it sees from the RUN switch, even during cold boot, because it treats the latched remote RUN input as a start trigger (`runActive && !prevRunActive_`).【F:src/clearcore/ClearCoreRTM.cpp†L134-L186】 When the expansion board later issues `CMD;RESUME=AUTO;...` after completing the protocol upload, the ClearCore rejects it with `ERR_WRONG_STAT` because it is already in the `RUNNING` state and only accepts resume commands while `IDLE`.【F:include/ClearCoreRTM.h†L360-L420】 This matches the captured log where the CC reports repeated `ERR_WRONG_STAT` ACKs immediately after entering `RUNNING` when the XPB's active-low RUN line is held asserted during boot.
 
 The new cold boots performed with `RA.BIN`/`RB.BIN` deleted show the CC and XPB remaining in `IDLE` with steadily increasing `SW_AGE` so long as RUN stays low, proving the resume collision is limited to the “RUN held on boot” condition rather than a general resume failure.【F:logs/cold_boot_no_resume.txt†L1-L17】 Decide whether the CC should defer auto-starting until it has a chance to honor an incoming resume request, or whether the XPB should suppress the auto-resume command when it sees the CC already running.  Without that handshake, the two ends will fight and the stored resume step will never be applied.
 
@@ -11,7 +11,7 @@ With the RUN pin hard-low during boot, the XPB immediately advertises `RUN=1` th
 transitions into `RUNNING` as soon as it leaves the protocol loader.
 `ClearCoreRTM::tick()` only requires a rising edge while already in `Idle` to promote the
 state, so a latched RUN input at boot causes the CC to advance before the XPB can finish
-its auto-resume negotiation.【F:src/clearcore/ClearCoreRTM.cpp†L131-L170】【F:include/ClearCoreRTM.h†L300-L312】
+its auto-resume negotiation.【F:src/clearcore/ClearCoreRTM.cpp†L134-L175】【F:include/ClearCoreRTM.h†L305-L315】
 
 When RUN stays low—as in the new captures—the LCD’s `SW age` counter increments normally and both controllers sit in `IDLE`, so the steady-state display path checks out.【F:logs/cold_boot_no_resume.txt†L1-L17】 The problem shows up only in the latched-run boot: the LCD keeps receiving `SW;RUN=1` updates every few hundred milliseconds, so `SW age` sticks at zero even though the CC has already entered `RUNNING`. Consider exposing the latched RUN state and/or CC state string on the LCD whenever the CC is actively running so technicians can see that the system is live.【F:src/exp-board/ExpansionBoard.cpp†L783-L829】
 
@@ -23,7 +23,7 @@ The ClearCore prints a duplicate `PR_END` notice as well as `WARN: TTL bad check
 
 ## 5. Miscellaneous follow-ups
 * Confirm that the XPB backs off after the CC reports `ERR_WRONG_STAT`; the log shows multiple retries with the same REF, so ensure the retry policy stops once an explicit error ACK is received.【F:src/shared/TTLComms.cpp†L258-L353】
-* Verify whether the heater setpoint / preheat command path is exercised during an auto-resume.  If the CC suppresses auto-start to wait for XPB resume, make sure the stored step's temperature target still flows through the preheat handler before resuming motion.【F:include/ClearCoreRTM.h†L402-L423】【F:src/clearcore/ClearCoreRTM.cpp†L132-L166】
+* Verify whether the heater setpoint / preheat command path is exercised during an auto-resume.  If the CC suppresses auto-start to wait for XPB resume, make sure the stored step's temperature target still flows through the preheat handler before resuming motion.【F:include/ClearCoreRTM.h†L399-L418】【F:src/clearcore/ClearCoreRTM.cpp†L145-L175】
 
 ## 6. User-requested reset flow
 The operator-driven reset capture shows the controllers exchanging the full `RESET=ARM`/`RESET=EXEC` handshake while both ends sit in `WAITING_XPB`, so the high-level flow is wired correctly.【F:logs/user_requested_reset.txt†L1-L127】【F:logs/user_requested_reset.txt†L129-L268】 Still, three issues surface:
@@ -35,7 +35,23 @@ The operator-driven reset capture shows the controllers exchanging the full `RES
 ## 7. Path to resolution
 To iron out the boot-and-reset issues captured so far:
 
-* Gate the ClearCore's auto-run promotion behind an explicit XPB resume allowance (or have the XPB suppress its resume when RUN is already high) so we never enter the `ERR_WRONG_STAT` retry loop.【F:src/clearcore/ClearCoreRTM.cpp†L132-L170】【F:logs/cold_boot_no_resume.txt†L1-L17】
+* Gate the ClearCore's auto-run promotion behind an explicit XPB resume allowance (or have the XPB
+  suppress its resume when RUN is already high) so we never enter the `ERR_WRONG_STAT` retry loop.
+  **Update:** the ClearCore now keeps the active-low RUN masked through `BOOT/PROTO_LOADING`, then
+  reopens the gate once the protocol upload completes. If RUN is still asserted at that moment we
+  queue a single synthetic edge so the controller preheats/resumes automatically after verification,
+  matching the power-loss auto-resume expectation.【F:src/clearcore/ClearCoreRTM.cpp†L103-L205】【F:include/ClearCoreRTM.h†L131-L200】
+  * **Validation plan:**
+    1. Cold-boot both controllers with the XPB RUN pin held low (call-for-run) and confirm the CC
+       stays in `BOOT/PROTO_LOADING` while logging `[RUN] Ignoring RUN line held low before XPB
+       resume` until the line is released high or a `RESUME AUTOSTART=1` arrives; this exercises the
+       `runGateReleased_` guard reset in `handleBoot()`.【F:src/clearcore/ClearCoreRTM.cpp†L116-L205】
+    2. After the XPB handshake completes, momentarily release RUN high and drive it low again to
+       verify the controller transitions from `IDLE` into `PREHEAT/RUN`, proving the gate opens once
+       the active-low line has been seen high.【F:src/clearcore/ClearCoreRTM.cpp†L134-L175】
+    3. From `IDLE`, send `RESUME AUTOSTART=1` while keeping RUN asserted low and confirm the
+       ClearCore accepts the resume and advances only after the XPB command; this covers the resume
+       handler overriding the gate for coordinated auto-starts.【F:include/ClearCoreRTM.h†L360-L413】
 * Surface RUN/RESET latch state on the LCD whenever the controller is not idle, and make the switch-age timer freeze explicitly signal "RUN held" so operators know why the system started without interaction.【F:src/exp-board/ExpansionBoard.cpp†L783-L829】【F:logs/user_requested_reset.txt†L69-L127】
 * Instrument the TTL transport for checksum failures and ensure duplicate `PR_END` / `QUIESCE` frames are genuine retries; add back-off so we do not spam commands when the peer already acknowledged them.【F:src/shared/TTLComms.cpp†L258-L353】【F:logs/user_requested_reset.txt†L85-L127】
 * Harden resume persistence: wrap the snapshot writer with retries and surface failures prominently, then verify the reset flow waits for a confirmed snapshot before forcing the XPB reset.【F:logs/user_requested_reset.txt†L96-L119】

--- a/README.md
+++ b/README.md
@@ -113,3 +113,4 @@ Additional details to capture as the design matures:
 * Capture enclosure photos that highlight mounting points, emergency stop hardware, and cable routing for technicians and auditors.
 
 This README will be expanded as more hardware information becomes available and the control software evolves.
+

--- a/include/ClearCoreRTM.h
+++ b/include/ClearCoreRTM.h
@@ -131,10 +131,16 @@ private:
     /* ——— user input ——— */
     bool        runActiveRemote_   = false;
     bool        resetActiveRemote_ = false;
+    bool        runGateReleased_   = false; //!< RUN line (active-low) ignored until XPB grants start or we observe a post-boot high
+    bool        latchedRunPending_ = false; //!< Latched RUN request awaiting protocol verification
     uint32_t    swLastUpdateMs_    = 0;
 
     // string mapping for displaying active state on LCD
     static const char* const kStateNames[11];
+    static_assert(
+        static_cast<uint8_t>(State::EStop) + 1 ==
+        sizeof(kStateNames) / sizeof(kStateNames[0]),
+        "kStateNames must match ClearCoreRTM::State");
     static inline const char * stateToString(State s) {
         return kStateNames[static_cast<uint8_t>(s)];
     }
@@ -387,7 +393,10 @@ private:
                         // Apply the resume position
                         owner_->currentStep_ = (uint16_t)(resumeStep - 1);  // Convert to 0-based index
                         owner_->loopCount_ = owner_->totalLoops_ - (uint32_t)resumeLoop + 1;
-                        
+
+                        // Allow future RUN edges now that XPB has explicitly coordinated resume
+                        owner_->runGateReleased_ = true;   // XPB explicitly allowed coordinated start
+
                         // --- Gating Rules ---
                         // if AUTOSTART==0 or RUN is not LOW, don't preheat nor start.
                         if (autoStart != 1 || !runIsEngaged) {
@@ -631,6 +640,13 @@ private:
                     owner_->dbgln("[PROTO] Upload complete - ready to run");
                     owner_->state_ = State::Idle;
                     owner_->isProtoLoaded_ = true;
+                    owner_->runGateReleased_ = true;
+                    owner_->latchedRunPending_ = owner_->runActiveRemote_;
+                    if (owner_->latchedRunPending_) {
+                        owner_->dbgln("[RUN] Latched RUN will auto-start after proto verification");
+                    } else {
+                        owner_->dbgln("[RUN] Gate reopened after protocol verification");
+                    }
 
                 } else {
                     // Harmless duplicate PR_END (likely XPB retry): ACK & ignore

--- a/src/clearcore/ClearCoreRTM.cpp
+++ b/src/clearcore/ClearCoreRTM.cpp
@@ -11,15 +11,11 @@ const char* const ClearCoreRTM::kStateNames[11] = {
     "PREHEAT",          // State::Preheat
     "RUNNING",          // State::Running
     "PAUSED",           // State::Paused
-    "RESETTING",        // State::Resetting
+    "RESETTING",        // State::ResetRequested
     "RESUME",           // State::Resume
     "COMPLETED",        // State::Completed
     "E-STOP"            // State::EStop
 };
-static_assert(
-    static_cast<size_t>(ClearCoreRTM::State::EStop) + 1 ==
-        sizeof(ClearCoreRTM::kStateNames) / sizeof(ClearCoreRTM::kStateNames[0]),
-    "kStateNames must match ClearCoreRTM::State");
 
 bool ClearCoreRTM::begin() {
     /* USB Serial Comms for Debugging */
@@ -105,14 +101,35 @@ void ClearCoreRTM::tick() {
     }
 
     bool eStopActive  = !SAFETY_PIN.State();
-    bool runActive    = runActiveRemote_;
+    const bool runLineLow = runActiveRemote_;   // XPB publishes RUN=1 when the active-low line is asserted
     bool resetActive  = resetActiveRemote_;
+    const bool runRoseLow  = runLineLow && !prevRunActive_;
+    const bool runWentHigh = !runLineLow && prevRunActive_;
 
     // first check for E-Stop
     if (eStopActive && state_ != State::EStop) {
         estopReason_ |= ESTOP_SAFETY;      // <— tag hardware cause
         eStopAll_("HW E-STOP input");
         return;
+    }
+
+    if (!runGateReleased_ && runWentHigh) {
+        runGateReleased_   = true;   // XPB line returned high, treat future low transitions as intentional
+        latchedRunPending_ = false;
+        dbgln("[RUN] Gate released: XPB RUN returned high");
+    }
+
+    bool runRiseAllowed = false;
+    if (runGateReleased_) {
+        if (runRoseLow) {
+            runRiseAllowed = true;
+        } else if (latchedRunPending_ && runLineLow) {
+            latchedRunPending_ = false;
+            runRiseAllowed     = true;
+            dbgln("[RUN] Auto-promoting latched RUN after protocol verification");
+        }
+    } else if (runRoseLow) {
+        dbgln("[RUN] Ignoring RUN line held low before XPB resume");
     }
 
     // transition logic for pause / resume / start
@@ -129,11 +146,11 @@ void ClearCoreRTM::tick() {
         prevResetActive_ = resetActive;
 
         // --- RUN logic: pause on level, start/resume on RISING EDGE only ---
-        if (!runActive && !resetActive && state_ == State::Running) {
+        if (!runLineLow && !resetActive && state_ == State::Running) {
             // switch moved out of RUN while running -> pause
             state_ = State::Paused;
         }
-        else if ((runActive && !prevRunActive_) && state_ == State::Paused) {
+        else if (runRiseAllowed && state_ == State::Paused) {
             // If cold start and targetC > 0 we should preheat before resuming motion
             const uint16_t targetC = steps_[currentStep_].tempC;
             if (coldStart_ && targetC > 0) {
@@ -150,7 +167,7 @@ void ClearCoreRTM::tick() {
                 state_ = State::Resume;          // fast path, no preheat needed
             }
         }
-        else if ((runActive && !prevRunActive_) && state_ == State::Idle) {
+        else if (runRiseAllowed && state_ == State::Idle) {
             const uint16_t targetC = steps_[currentStep_].tempC;
             if (coldStart_ && targetC > 0) {
                 state_                 = State::Preheat;
@@ -165,10 +182,10 @@ void ClearCoreRTM::tick() {
                 state_ = State::Running;         // fast path, no preheat needed
             }
         }
-
-        // latch for next tick
-        prevRunActive_ = runActive;
     }
+
+    // latch for next tick (even during BOOT/PROTO_LOADING so we catch high transitions)
+    prevRunActive_ = runLineLow;
 
     // justEntered_ allows us to do things once upon first entering a state handler
     bool justEntered_ = (state_ != prevState_); // did we just state change?
@@ -181,22 +198,22 @@ void ClearCoreRTM::tick() {
     // dispatch to state handlers
     switch (state_) {
         case State::BOOT:
-            handleBoot(runActive, justEntered_);
+            handleBoot(resetActive, justEntered_);
             break;
         case State::PROTO_LOADING:
             handleProtoLoad(justEntered_);
             break;
         case State::Idle:
-            handleIdle(runActive, justEntered_);
+            handleIdle(runLineLow, justEntered_);
             break;
         case State::Preheat:
-            handlePreheat(runActive, justEntered_);
+            handlePreheat(runLineLow, justEntered_);
             break;
         case State::Running:
-            handleRunning(runActive, justEntered_);
+            handleRunning(runLineLow, justEntered_);
             break;
         case State::Paused:
-            handlePaused(runActive, justEntered_);
+            handlePaused(runLineLow, justEntered_);
             break;
         case State::ResetRequested:
             handleReset(resetActive, justEntered_);
@@ -205,7 +222,7 @@ void ClearCoreRTM::tick() {
             handleEStop(resetActive, justEntered_);
             break;
         case State::Resume:
-            handleResume(runActive, justEntered_);
+            handleResume(runLineLow, justEntered_);
             break;
         case State::Completed:
             handleCompleted(resetActive, justEntered_);
@@ -243,7 +260,9 @@ void ClearCoreRTM::tick() {
 
 /* ——— State Handlers ——— */
 void ClearCoreRTM::handleBoot(bool resetActive, bool justEntered_) {
-    if (justEntered_) { 
+    if (justEntered_) {
+        runGateReleased_   = false;   // active-low RUN stays masked until XPB grants it again
+        latchedRunPending_ = false;
         heartbeatSystemEnabled_ = false;
         protoRequestTmr_ = 0;
 

--- a/src/exp-board/ExpansionBoard.cpp
+++ b/src/exp-board/ExpansionBoard.cpp
@@ -974,13 +974,14 @@ bool ExpansionBoard::loadProtocolFromSD_(const char *path) {
   return (stepCount_ > 0);
 }
 
-void ExpansionBoard::clearResumeSlots_() {
-    (void)deleteIfExists_("/RA.BIN");
-    (void)deleteIfExists_("/RB.BIN");
-}
 static bool deleteIfExists_(const char *path) {
     if (!SD.exists(path)) return true;
     return SD.remove(path);
+}
+
+void ExpansionBoard::clearResumeSlots_() {
+    (void)deleteIfExists_("/RA.BIN");
+    (void)deleteIfExists_("/RB.BIN");
 }
 
 /**


### PR DESCRIPTION
## Summary
- track whether the XPB-run line was latched low during boot and synthesize a start edge after the protocol upload finishes
- reopen the run gate once the XPB handshake completes and document the new auto-resume flow in the review log

## Testing
- not run (PlatformIO CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e919e2fe248321a81267a37da68d4c